### PR TITLE
feat: 실시간 채팅 기능 구현

### DIFF
--- a/apps/mobile/app/channel/[userId]/page.tsx
+++ b/apps/mobile/app/channel/[userId]/page.tsx
@@ -4,12 +4,26 @@ import { useEffect, useState } from 'react';
 import ReactPlayer from 'react-player';
 import { getChannelByUserId } from '@repo/logic/api/stream';
 import { Channel } from '@repo/logic/domain/channel';
+import { chatService } from '@repo/logic/api/chat';
+import { useAuth } from '@repo/logic/context/auth-context';
+import type { ChatMessage } from '@repo/logic/domain/chat';
+import { Chat } from '@repo/ui/chat';
 
-// Assuming a basic layout and styles
 const styles = {
   page: {
     padding: '2rem',
     fontFamily: 'sans-serif',
+  },
+  layout: {
+    display: 'flex',
+    gap: '2rem',
+  },
+  mainContent: {
+    flex: 3,
+  },
+  chatAside: {
+    flex: 1,
+    height: 'calc(100vh - 4rem)', // Adjust height as needed
   },
   playerWrapper: {
     position: 'relative',
@@ -29,7 +43,10 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
   const [channel, setChannel] = useState<Channel | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const { user: currentUser, isAuthenticated } = useAuth();
 
+  // Fetch channel data
   useEffect(() => {
     if (!params.userId) return;
 
@@ -48,6 +65,41 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
 
     fetchChannel();
   }, [params.userId]);
+
+  // Manage chat connection
+  useEffect(() => {
+    if (!channel?.stream.id) return;
+
+    chatService.connect();
+    chatService.joinRoom(channel.stream.id);
+
+    chatService.onNewMessage((message) => {
+      setMessages((prevMessages) => [...prevMessages, message]);
+    });
+
+    chatService.onError((error) => {
+      console.error('Chat Error:', error.message);
+      // Optionally show an error to the user in the chat UI
+    });
+
+    // Cleanup on component unmount
+    return () => {
+      chatService.leaveRoom(channel.stream.id);
+      chatService.offNewMessage();
+      chatService.offError();
+      chatService.disconnect();
+      setMessages([]); // Clear messages on leave
+    };
+  }, [channel]);
+
+  const handleSendMessage = (text: string) => {
+    if (!currentUser || !channel) return;
+    chatService.sendMessage({
+      streamId: channel.stream.id,
+      userId: currentUser.id,
+      text,
+    });
+  };
 
   if (loading) {
     return <div style={styles.page}><p>Loading channel...</p></div>;
@@ -70,24 +122,35 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
         <h2>Streamed by: {channel.user.username}</h2>
       </header>
 
-      {channel.stream.isLive ? (
-        <div style={styles.playerWrapper}>
-          <ReactPlayer
-            style={styles.reactPlayer}
-            url={streamUrl}
-            playing
-            controls
-            width="100%"
-            height="100%"
-          />
+      <div style={styles.layout}>
+        <div style={styles.mainContent}>
+          {channel.stream.isLive ? (
+            <div style={styles.playerWrapper}>
+              <ReactPlayer
+                style={styles.reactPlayer}
+                url={streamUrl}
+                playing
+                controls
+                width="100%"
+                height="100%"
+              />
+            </div>
+          ) : (
+            <p>This stream is not live right now.</p>
+          )}
+          <div style={styles.info}>
+            <h3>About this stream:</h3>
+            <p>{channel.stream.description}</p>
+          </div>
         </div>
-      ) : (
-        <p>This stream is not live right now.</p>
-      )}
 
-      <div style={styles.info}>
-        <h3>About this stream:</h3>
-        <p>{channel.stream.description}</p>
+        <aside style={styles.chatAside}>
+          <Chat 
+            messages={messages} 
+            onSendMessage={handleSendMessage} 
+            disabled={!isAuthenticated}
+          />
+        </aside>
       </div>
     </div>
   );

--- a/apps/web/app/channel/[userId]/page.tsx
+++ b/apps/web/app/channel/[userId]/page.tsx
@@ -4,12 +4,26 @@ import { useEffect, useState } from 'react';
 import ReactPlayer from 'react-player';
 import { getChannelByUserId } from '@repo/logic/api/stream';
 import { Channel } from '@repo/logic/domain/channel';
+import { chatService } from '@repo/logic/api/chat';
+import { useAuth } from '@repo/logic/context/auth-context';
+import type { ChatMessage } from '@repo/logic/domain/chat';
+import { Chat } from '@repo/ui/chat';
 
-// Assuming a basic layout and styles
 const styles = {
   page: {
     padding: '2rem',
     fontFamily: 'sans-serif',
+  },
+  layout: {
+    display: 'flex',
+    gap: '2rem',
+  },
+  mainContent: {
+    flex: 3,
+  },
+  chatAside: {
+    flex: 1,
+    height: 'calc(100vh - 4rem)', // Adjust height as needed
   },
   playerWrapper: {
     position: 'relative',
@@ -29,7 +43,10 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
   const [channel, setChannel] = useState<Channel | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const { user: currentUser, isAuthenticated } = useAuth();
 
+  // Fetch channel data
   useEffect(() => {
     if (!params.userId) return;
 
@@ -48,6 +65,41 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
 
     fetchChannel();
   }, [params.userId]);
+
+  // Manage chat connection
+  useEffect(() => {
+    if (!channel?.stream.id) return;
+
+    chatService.connect();
+    chatService.joinRoom(channel.stream.id);
+
+    chatService.onNewMessage((message) => {
+      setMessages((prevMessages) => [...prevMessages, message]);
+    });
+
+    chatService.onError((error) => {
+      console.error('Chat Error:', error.message);
+      // Optionally show an error to the user in the chat UI
+    });
+
+    // Cleanup on component unmount
+    return () => {
+      chatService.leaveRoom(channel.stream.id);
+      chatService.offNewMessage();
+      chatService.offError();
+      chatService.disconnect();
+      setMessages([]); // Clear messages on leave
+    };
+  }, [channel]);
+
+  const handleSendMessage = (text: string) => {
+    if (!currentUser || !channel) return;
+    chatService.sendMessage({
+      streamId: channel.stream.id,
+      userId: currentUser.id,
+      text,
+    });
+  };
 
   if (loading) {
     return <div style={styles.page}><p>Loading channel...</p></div>;
@@ -70,24 +122,35 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
         <h2>Streamed by: {channel.user.username}</h2>
       </header>
 
-      {channel.stream.isLive ? (
-        <div style={styles.playerWrapper}>
-          <ReactPlayer
-            style={styles.reactPlayer}
-            url={streamUrl}
-            playing
-            controls
-            width="100%"
-            height="100%"
-          />
+      <div style={styles.layout}>
+        <div style={styles.mainContent}>
+          {channel.stream.isLive ? (
+            <div style={styles.playerWrapper}>
+              <ReactPlayer
+                style={styles.reactPlayer}
+                url={streamUrl}
+                playing
+                controls
+                width="100%"
+                height="100%"
+              />
+            </div>
+          ) : (
+            <p>This stream is not live right now.</p>
+          )}
+          <div style={styles.info}>
+            <h3>About this stream:</h3>
+            <p>{channel.stream.description}</p>
+          </div>
         </div>
-      ) : (
-        <p>This stream is not live right now.</p>
-      )}
 
-      <div style={styles.info}>
-        <h3>About this stream:</h3>
-        <p>{channel.stream.description}</p>
+        <aside style={styles.chatAside}>
+          <Chat 
+            messages={messages} 
+            onSendMessage={handleSendMessage} 
+            disabled={!isAuthenticated}
+          />
+        </aside>
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       ],
       "dependencies": {
         "jwt-decode": "^4.0.0",
-        "react-player": "^3.3.3"
+        "react-player": "^3.3.3",
+        "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -1074,6 +1075,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
     "node_modules/@svta/common-media-library": {
@@ -2542,6 +2549,45 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -4515,7 +4561,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mux-embed": {
@@ -5507,6 +5552,68 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6332,6 +6439,35 @@
       "dev": true,
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "jwt-decode": "^4.0.0",
-    "react-player": "^3.3.3"
+    "react-player": "^3.3.3",
+    "socket.io-client": "^4.8.1"
   }
 }

--- a/packages/logic/src/api/chat.ts
+++ b/packages/logic/src/api/chat.ts
@@ -1,0 +1,64 @@
+import { io, Socket } from 'socket.io-client';
+import type { ChatMessage } from '../domain/chat';
+
+const SOCKET_URL = 'http://localhost:3000'; // As per the provided spec
+
+let socket: Socket;
+
+export const chatService = {
+  connect: () => {
+    if (socket) return;
+    socket = io(SOCKET_URL, {
+      transports: ['websocket'], // Prefer websockets
+    });
+
+    socket.on('connect', () => {
+      console.log('Socket.IO connected:', socket.id);
+    });
+
+    socket.on('disconnect', () => {
+      console.log('Socket.IO disconnected');
+    });
+  },
+
+  disconnect: () => {
+    if (socket) {
+      socket.disconnect();
+    }
+  },
+
+  joinRoom: (streamId: string) => {
+    if (!socket) return;
+    socket.emit('joinRoom', streamId);
+  },
+
+  leaveRoom: (streamId: string) => {
+    if (!socket) return;
+    socket.emit('leaveRoom', streamId);
+  },
+
+  sendMessage: (payload: { streamId: string; text: string; userId: string }) => {
+    if (!socket) return;
+    socket.emit('sendMessage', payload);
+  },
+
+  onNewMessage: (callback: (message: ChatMessage) => void) => {
+    if (!socket) return;
+    socket.on('newMessage', callback);
+  },
+
+  offNewMessage: () => {
+    if (!socket) return;
+    socket.off('newMessage');
+  },
+
+  onError: (callback: (error: { message: string }) => void) => {
+    if (!socket) return;
+    socket.on('error', callback);
+  },
+
+  offError: () => {
+    if (!socket) return;
+    socket.off('error');
+  },
+};

--- a/packages/logic/src/domain/chat.ts
+++ b/packages/logic/src/domain/chat.ts
@@ -1,0 +1,12 @@
+import type { User } from './user';
+
+// Based on schema.prisma
+// The payload for the 'newMessage' event is expected to include the user details.
+export interface ChatMessage {
+  id: string;
+  text: string;
+  createdAt: string; // Date will be serialized as a string
+  streamId: string;
+  userId: string;
+  user: Pick<User, 'id' | 'username'>; // We only need id and username for display
+}

--- a/packages/ui/src/chat.tsx
+++ b/packages/ui/src/chat.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ChatMessage } from '@repo/logic/domain/chat';
+
+export interface ChatProps {
+  messages: ChatMessage[];
+  onSendMessage: (text: string) => void;
+  disabled?: boolean;
+}
+
+const chatStyles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column' as 'column',
+    height: '100%',
+    border: '1px solid #ccc',
+    borderRadius: '8px',
+    overflow: 'hidden',
+    fontFamily: 'sans-serif',
+  },
+  messageList: {
+    flexGrow: 1,
+    padding: '1rem',
+    overflowY: 'auto' as 'auto',
+    background: '#f9f9f9',
+  },
+  message: {
+    marginBottom: '0.5rem',
+  },
+  messageUser: {
+    fontWeight: 'bold' as 'bold',
+    marginRight: '0.5rem',
+  },
+  form: {
+    display: 'flex',
+    padding: '1rem',
+    borderTop: '1px solid #ccc',
+    background: '#fff',
+  },
+  input: {
+    flexGrow: 1,
+    padding: '0.5rem',
+    border: '1px solid #ccc',
+    borderRadius: '4px',
+    marginRight: '0.5rem',
+  },
+  button: {
+    padding: '0.5rem 1rem',
+    border: 'none',
+    background: '#007bff',
+    color: 'white',
+    borderRadius: '4px',
+    cursor: 'pointer',
+  },
+  buttonDisabled: {
+    background: '#aaa',
+    cursor: 'not-allowed',
+  },
+};
+
+export function Chat({ messages, onSendMessage, disabled = false }: ChatProps) {
+  const [text, setText] = React.useState('');
+  const messageListRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    // Scroll to the bottom when new messages arrive
+    if (messageListRef.current) {
+      messageListRef.current.scrollTop = messageListRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (text.trim() && !disabled) {
+      onSendMessage(text.trim());
+      setText('');
+    }
+  };
+
+  return (
+    <div style={chatStyles.container}>
+      <div style={chatStyles.messageList} ref={messageListRef}>
+        {messages.map((msg) => (
+          <div key={msg.id} style={chatStyles.message}>
+            <span style={chatStyles.messageUser}>{msg.user.username}:</span>
+            <span>{msg.text}</span>
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} style={chatStyles.form}>
+        <input
+          type="text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={disabled ? 'Connecting...' : 'Type a message...'}
+          style={chatStyles.input}
+          disabled={disabled}
+        />
+        <button 
+          type="submit" 
+          style={disabled ? {...chatStyles.button, ...chatStyles.buttonDisabled} : chatStyles.button} 
+          disabled={disabled}
+        >
+          Send
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요 (Overview)

이 PR은 `PLAN.md`의 4단계인 '실시간 채팅' 기능을 구현합니다. 사용자가 방송을 시청하면서 다른 참여자들과 실시간으로 메시지를 주고받을 수 있는 기능을 웹과 모바일 앱에 추가합니다.

## 주요 변경 사항 (Key Changes)

### 1. 종속성 및 로직 추가
- **`socket.io-client`**: 실시간 통신을 위해 종속성을 추가했습니다.
- **채팅 타입**: `ChatMessage` 타입을 `packages/logic/domain`에 정의했습니다.
- **채팅 서비스**: 소켓 연결, 이벤트 송수신 등 모든 소켓 통신을 캡슐화한 `chatService`를 `packages/logic/api`에 구현했습니다.

### 2. UI 구현
- **`Chat` 컴포넌트**: 메시지 목록과 입력 폼을 포함하는 재사용 가능한 `Chat` 컴포넌트를 `packages/ui`에 추가했습니다.

### 3. 기능 통합 (Closes #20)
- **채팅 기능 연동**: `apps/web`과 `apps/mobile`의 방송 시청 페이지에 `Chat` 컴포넌트를 추가했습니다.
- **라이프사이클 관리**: 페이지 진입 시 소켓 연결 및 채팅방에 참여(`joinRoom`)하고, 이탈 시 연결을 해제(`leaveRoom`, `disconnect`)하도록 라이프사이클을 관리합니다.
- **메시지 송수신**: `useAuth` 훅으로 현재 사용자 정보를 가져와 메시지를 전송하고, `chatService`를 통해 새로운 메시지를 수신하여 화면에 표시합니다.
- **레이아웃 변경**: 기존의 단일 뷰에서 비디오 플레이어와 채팅창이 나란히 표시되는 2단 레이아웃으로 변경했습니다.

## 참고 (Reference)

- GitHub Issue: #20
