### PR TITLE
feat(chat): 채팅 UI 개선 (closes #26)

### DIFF
--- a/apps/mobile/app/channel/[userId]/page.tsx
+++ b/apps/mobile/app/channel/[userId]/page.tsx
@@ -91,6 +91,14 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
         setMessages((prevMessages) => [...prevMessages, message]);
       });
 
+      chatService.onUserJoined((message) => {
+        setMessages((prevMessages) => [...prevMessages, message]);
+      });
+
+      chatService.onUserLeft((message) => {
+        setMessages((prevMessages) => [...prevMessages, message]);
+      });
+
       chatService.onError((error) => {
         console.error('Chat Error:', error.message);
         // Optionally show an error to the user in the chat UI
@@ -105,6 +113,8 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
       try {
         chatService.leaveRoom(channel.stream.id);
         chatService.offNewMessage();
+        chatService.offUserJoined();
+        chatService.offUserLeft();
         chatService.offError();
         chatService.disconnect();
         setMessages([]); // Clear messages on leave

--- a/apps/web/app/channel/[userId]/page.tsx
+++ b/apps/web/app/channel/[userId]/page.tsx
@@ -91,6 +91,14 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
         setMessages((prevMessages) => [...prevMessages, message]);
       });
 
+      chatService.onUserJoined((message) => {
+        setMessages((prevMessages) => [...prevMessages, message]);
+      });
+
+      chatService.onUserLeft((message) => {
+        setMessages((prevMessages) => [...prevMessages, message]);
+      });
+
       chatService.onError((error) => {
         console.error('Chat Error:', error.message);
         // Optionally show an error to the user in the chat UI
@@ -105,6 +113,8 @@ export default function ChannelPage({ params }: { params: { userId: string } }) 
       try {
         chatService.leaveRoom(channel.stream.id);
         chatService.offNewMessage();
+        chatService.offUserJoined();
+        chatService.offUserLeft();
         chatService.offError();
         chatService.disconnect();
         setMessages([]); // Clear messages on leave

--- a/packages/logic/src/api/chat.ts
+++ b/packages/logic/src/api/chat.ts
@@ -75,4 +75,41 @@ export const chatService = {
   offError: () => {
     getSocket().off('error');
   },
+
+  onUserJoined: (callback: (message: ChatMessage) => void) => {
+    getSocket().on('userJoined', ({ userId, username }: { userId: string; username: string }) => {
+      callback({
+        id: `system-${userId}-${Date.now()}`,
+        text: `${username} has joined the chat.`,
+        createdAt: new Date().toISOString(),
+        isSystem: true,
+        // Fill other required fields as appropriate for a system message
+        streamId: '', // Or get it from context if available
+        userId,
+        user: { id: userId, username },
+      });
+    });
+  },
+
+  offUserJoined: () => {
+    getSocket().off('userJoined');
+  },
+
+  onUserLeft: (callback: (message: ChatMessage) => void) => {
+    getSocket().on('userLeft', ({ userId, username }: { userId: string; username: string }) => {
+      callback({
+        id: `system-${userId}-${Date.now()}`,
+        text: `${username} has left the chat.`,
+        createdAt: new Date().toISOString(),
+        isSystem: true,
+        streamId: '',
+        userId,
+        user: { id: userId, username },
+      });
+    });
+  },
+
+  offUserLeft: () => {
+    getSocket().off('userLeft');
+  },
 };

--- a/packages/logic/src/domain/chat.ts
+++ b/packages/logic/src/domain/chat.ts
@@ -9,4 +9,5 @@ export interface ChatMessage {
   streamId: string;
   userId: string;
   user: Pick<User, 'id' | 'username'>; // We only need id and username for display
+  isSystem?: boolean; // To flag system messages like 'user joined'
 }

--- a/packages/ui/src/chat.tsx
+++ b/packages/ui/src/chat.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import type { ChatMessage } from '@repo/logic/domain/chat';
+import { generateColorFromString } from './lib/color';
 
 export interface ChatProps {
   messages: ChatMessage[];
@@ -28,10 +29,21 @@ const chatStyles = {
   },
   message: {
     marginBottom: '0.5rem',
+    lineHeight: '1.4',
+  },
+  systemMessage: {
+    fontStyle: 'italic' as const,
+    color: '#888',
+    textAlign: 'center' as const,
   },
   messageUser: {
     fontWeight: 'bold' as const,
     marginRight: '0.5rem',
+  },
+  timestamp: {
+    fontSize: '0.75rem',
+    color: '#999',
+    marginLeft: '0.5rem',
   },
   form: {
     display: 'flex',
@@ -79,13 +91,37 @@ export function Chat({ messages, onSendMessage, disabled = false }: ChatProps) {
     }
   };
 
+  const formatTimestamp = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
   return (
     <div style={chatStyles.container}>
       <div style={chatStyles.messageList} ref={messageListRef}>
         {messages.map((msg) => (
-          <div key={msg.id} style={chatStyles.message}>
-            <span style={chatStyles.messageUser}>{msg.user.username}:</span>
-            <span>{msg.text}</span>
+          <div 
+            key={msg.id} 
+            style={msg.isSystem ? {...chatStyles.message, ...chatStyles.systemMessage} : chatStyles.message}
+          >
+            {msg.isSystem ? (
+              <span>{msg.text}</span>
+            ) : (
+              <>
+                <span 
+                  style={{ 
+                    ...chatStyles.messageUser, 
+                    color: generateColorFromString(msg.user.id)
+                  }}
+                >
+                  {msg.user.username}:
+                </span>
+                <span>{msg.text}</span>
+                <span style={chatStyles.timestamp}>
+                  {formatTimestamp(msg.createdAt)}
+                </span>
+              </>
+            )}
           </div>
         ))}
       </div>

--- a/packages/ui/src/lib/color.ts
+++ b/packages/ui/src/lib/color.ts
@@ -1,0 +1,20 @@
+/* eslint-disable no-bitwise */
+
+/**
+ * Generates a consistent, visually appealing color from a string (e.g., a user ID).
+ * This hashing function is simple and not cryptographically secure.
+ */
+export function generateColorFromString(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  // Use HSL for more visually pleasing and distinct colors
+  const h = hash % 360;
+  // Keep saturation and lightness within a pleasant range
+  const s = 70; // 70% saturation
+  const l = 50; // 50% lightness
+
+  return `hsl(${h}, ${s}%, ${l}%)`;
+}


### PR DESCRIPTION
## 개요 (Overview)

이 PR은 `PLAN.md`의 4단계 '실시간 채팅'의 일환으로, 채팅 UI의 사용성을 개선하는 데 중점을 둡니다.

## 주요 변경 사항 (Key Changes)

### 1. 채팅 UI 고도화 (Closes #26)
- **타임스탬프 표시**: 각 채팅 메시지 옆에 전송 시간을 표시하여 가독성을 높였습니다.
- **사용자 이름 색상 적용**: 사용자 ID를 기반으로 고유한 색상을 생성하여 사용자 구분을 용이하게 했습니다.
- **시스템 메시지 구분**: 사용자의 입/퇴장과 같은 시스템 메시지를 일반 메시지와 시각적으로 다르게 표시하여 채팅 흐름을 명확히 했습니다.
- **타입 확장 및 핸들러 추가**: 시스템 메시지를 처리하기 위해 `ChatMessage` 타입을 확장하고, `chatService`에 `onUserJoined`, `onUserLeft` 등의 이벤트 핸들러를 추가했습니다.

## 참고 (Reference)

- GitHub Issue: #26