### PR TITLE
로컬 썸네일/소켓 연결 설정 보정

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -1,0 +1,34 @@
+# Project Structure
+
+- root
+  - `apps/` — App targets
+    - `web/` — Next.js 웹 클라이언트 (`app/` 라우트 기반, Turbopack dev)
+      - `app/` — 기능별 폴더(`channel`, `vod`, `login`, `signup`, `me`, `presentation`, `application`, `domain`, `infrastructure`, `fonts`)와 전역 레이아웃 (`layout.tsx`, `globals.css`)
+    - `mobile/` — Next.js 기반 RN-shell 웹 프리뷰 (웹과 동일한 라우트 구조)
+      - `app/` — `channel`, `vod`, `login`, `signup`, `presentation` 등 웹과 동일한 구조
+  - `packages/` — 공유 패키지
+    - `logic/` — 비즈니스/네트워크 로직
+      - `src/api/` — API 클라이언트, 도메인별 API(`chat`, `stream`, `auth` 등)
+      - `src/auth/` — 토큰 스토리지 등 인증 유틸
+      - `src/context/` — 전역 컨텍스트(`auth-context`)
+      - `src/domain/` — 도메인 타입 정의
+      - `api-client.ts`, `index.ts` — axios 설정, 패키지 엔트리
+    - `ui/` — 공유 UI 컴포넌트/레이아웃
+      - `src/chat.tsx`, `button.tsx`, `card.tsx`, `layout.tsx`, `header.tsx`, `lib/color.ts` 등
+    - `eslint-config/`, `typescript-config/` — ESLint/TS 설정 패키지
+  - `package.json`, `turbo.json`, `playwright.config.ts` — 루트 설정
+  - `.env.example`, `.env.local` — 환경 변수 예시/로컬 설정
+  - `tests/`, `test-results/`, `server-info/` — 테스트/서버 메타 자료
+
+## 주요 경로
+- 스트리밍 뷰어 & 채팅: `apps/web/app/channel/[userId]/page.tsx`, `apps/mobile/app/channel/[userId]/page.tsx`
+- 스트리밍 로직: `packages/logic/src/api/stream.ts`, `packages/logic/src/api/chat.ts`
+- UI 공용 채팅 컴포넌트: `packages/ui/src/chat.tsx`
+
+## 빌드/개발 스크립트
+- 전체 dev: `npm run dev` (turbo)
+- 웹만 dev: `npx turbo run dev --filter=web`
+- 모바일만 dev: `npx turbo run dev --filter=mobile`
+- 빌드: `npm run build`
+- 린트: `npm run lint`
+- 타입 체크: `npm run check-types`

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -7,6 +7,18 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'placehold.co',
       },
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '4000',
+        pathname: '/static/**',
+      },
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+        port: '8000',
+        pathname: '/static/**',
+      },
     ],
   },
 };

--- a/packages/logic/src/api/chat.ts
+++ b/packages/logic/src/api/chat.ts
@@ -2,7 +2,7 @@ import { io, Socket } from 'socket.io-client';
 import type { ChatMessage } from '../domain/chat';
 import { tokenStorage } from '../auth/token-storage';
 
-const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_SERVER_URL || 'http://localhost:3000';
+const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_SERVER_URL || 'http://localhost:4000';
 const RECONNECT_MAX = 5;
 
 let socket: Socket | null = null;


### PR DESCRIPTION
## 개요
- 로컬 썸네일 URL을 next/image에서 허용하도록 설정했습니다.
- 소켓 기본 URL을 서버 포트(4000)로 맞췄습니다.

## 변경 사항
- apps/web/next.config.mjs: localhost:4000/8000 이미지 허용
- packages/logic/src/api/chat.ts: 기본 SOCKET URL → http://localhost:4000

## 테스트
- 미실행